### PR TITLE
Fix absolute paths to SVG sprite when building for production

### DIFF
--- a/app/src/jade/mixins/_svgsprite.jade
+++ b/app/src/jade/mixins/_svgsprite.jade
@@ -1,9 +1,9 @@
 mixin svg(id, viewbox, className)
 	if viewbox
 		svg(viewbox='#{viewbox}', class!=className)
-			use(xlink:href='/assets/img/sprite.svg##{id}')
+			use(xlink:href='assets/img/sprite.svg##{id}')
 	else
 		svg(viewbox='0 0 50 50', class!=className)
-			use(xlink:href='/assets/img/sprite.svg##{id}')
+			use(xlink:href='assets/img/sprite.svg##{id}')
 
 //- Usage: +svg('symbolID', 'viewbox parameters', 'classnames')


### PR DESCRIPTION
I ran into an issue while running the build:production command. The generated SVG sprite paths are pointing to an absolute path `/assets/img/` When working in a subdirectory of a domain this causes problems. 
